### PR TITLE
TR8*4 z_step correction

### DIFF
--- a/slicer_profiles/SuperSlicer/SuperSlicer_config_bundle-0.6.2.ini
+++ b/slicer_profiles/SuperSlicer/SuperSlicer_config_bundle-0.6.2.ini
@@ -1536,7 +1536,7 @@ wipe_advanced_multiplier = 60
 wipe_advanced_nozzle_melted_volume = 120
 wipe_extra_perimeter = 0
 z_offset = 0
-z_step = 0.00125
+z_step = 0.02
 
 [printer:v-core 400]
 bed_custom_model = C:\\Users\\detlev01\\Documents\\Downloads\\ratrig-vcore-bed-400x400.stl


### PR DESCRIPTION
z_step is the full step size without microstepping
for 4mm per rotation with a 1.8° Stepper that is 4/200 = 0.02